### PR TITLE
Updates client to send personal access token in header

### DIFF
--- a/confluence/client.go
+++ b/confluence/client.go
@@ -18,6 +18,7 @@ type Client struct {
 	baseURL   *url.URL
 	basePath  string
 	publicURL *url.URL
+	token     string
 }
 
 // NewClientInput provides information to connect to the Confluence API
@@ -63,7 +64,9 @@ func NewClient(input *NewClientInput) *Client {
 		Scheme: input.siteScheme,
 		Host:   input.site,
 	}
-	baseURL.User = url.UserPassword(input.user, input.token)
+	// This is the old version. Now we have to pass the token
+	// alone in a header
+	//baseURL.User = url.UserPassword(input.user, input.token)
 	return &Client{
 		client: &http.Client{
 			Timeout: time.Second * 10,
@@ -71,6 +74,7 @@ func NewClient(input *NewClientInput) *Client {
 		baseURL:   &baseURL,
 		basePath:  basePath,
 		publicURL: &publicURL,
+		token:     input.token,
 	}
 }
 
@@ -191,6 +195,7 @@ func (c *Client) doRaw(method, path, contentType string, body *bytes.Buffer) (*b
 		req.Header.Set("Content-Type", contentType)
 	}
 	req.Header.Add("X-Atlassian-Token", "nocheck")
+	req.Header.Add("Authorization", "Bearer " + c.token)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The existing provider using HTTP BASIC authenticaiton on our confluence. The new method is to use a header. See https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html

This quick fix implements the header authentication and gets the provider working again.

